### PR TITLE
chore: add provider abstraction scaffolding

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -6,7 +6,7 @@
 ---
 
 ## 1. Overview
-A cross-platform desktop application that provides a friendly GUI for interacting with Claude via the Claude CLI and optionally Claude Code, designed for non-technical users. The app bundles necessary CLI tooling, supports the latest models, and delivers an easy chat and coding experience.
+A cross-platform desktop application that provides a friendly GUI for interacting with Claude via the Claude CLI and optionally Claude Code, designed for non-technical users. The app bundles necessary CLI tooling, supports the latest models, and delivers an easy chat and coding experience. The architecture is intentionally modular so additional provider CLIs or SDKs (e.g., Codex or Gemini) can be supported in the future.
 
 ## 2. Goals
 - Deliver a minimal, intuitive interface for chatting with Claude.
@@ -16,6 +16,7 @@ A cross-platform desktop application that provides a friendly GUI for interactin
 - Provide basic integration with Claude Code for code navigation/editing.
 - Collect usage analytics and error reports for continual improvement.
 - Maintain high standards for security, privacy, and automatic updates.
+- Establish a provider abstraction layer that can later support other AI CLIs/SDKs (Codex, Gemini, etc.).
 
 ## 3. Non-Goals
 - Advanced theming/branding beyond a minimal default look.
@@ -397,6 +398,12 @@ class PermissionHandler {
 | `--resume` | string | Resume session by ID |
 | `--continue` | boolean | Continue recent session |
 | `--dangerously-skip-permissions` | boolean | Skip all prompts |
+
+### 6.5 Provider Abstraction Layer
+- **Purpose**: Allow the application to swap between different AI providers.
+- **Location**: Provider modules live in `src/providers/` (starting with a Claude CLI wrapper).
+- **Interface**: Each provider exposes a common API (e.g., `query(prompt, options)`) so the UI can remain provider-agnostic.
+- **Future Providers**: Codex CLI, Gemini CLI, and other SDK-based integrations can be added without major refactors.
 
 ## 10. Metrics & Success Criteria
 - **Activation**: % of users who send at least one message after installation.

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
+const providers = require('./providers'); // Future: support multiple AI providers
 
 function createWindow() {
   const win = new BrowserWindow({

--- a/src/providers/claude.js
+++ b/src/providers/claude.js
@@ -1,0 +1,34 @@
+const { spawn } = require('child_process');
+
+/**
+ * Minimal wrapper around the Claude CLI.
+ * Future providers (e.g., Codex CLI, Gemini CLI, SDKs) should expose the same interface.
+ * @param {string} prompt - Text prompt to send to the CLI.
+ * @param {object} [options] - Additional CLI options such as model.
+ * @returns {Promise<string>} - Resolves with the CLI response text.
+ */
+function queryClaude(prompt, options = {}) {
+  return new Promise((resolve, reject) => {
+    const args = ['--print'];
+    if (options.model) {
+      args.push('--model', options.model);
+    }
+
+    const proc = spawn('claude', args, { stdio: ['pipe', 'pipe', 'inherit'] });
+    let output = '';
+
+    proc.stdout.on('data', data => {
+      output += data.toString();
+    });
+
+    proc.on('error', reject);
+    proc.on('close', () => resolve(output.trim()));
+
+    proc.stdin.write(prompt);
+    proc.stdin.end();
+  });
+}
+
+module.exports = {
+  queryClaude,
+};

--- a/src/providers/index.js
+++ b/src/providers/index.js
@@ -1,0 +1,5 @@
+// Registry for AI provider clients.
+// Additional providers (e.g., Codex CLI, Gemini CLI, SDKs) can be added here.
+module.exports = {
+  claude: require('./claude'),
+};


### PR DESCRIPTION
## Summary
- document modular design in PRD for future Codex and Gemini CLI support
- scaffold provider registry and Claude CLI wrapper
- note provider support in main Electron entrypoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c90a8266c8320b033522b2140b596