### PR TITLE
feat: refine chatgpt-style interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Desktop
 
-MVP Electron application providing a graphical interface for interacting with the Claude CLI. The project includes a simple Hello World example to validate the Electron setup.
+MVP Electron application providing a graphical interface for interacting with the Claude CLI. The project now ships with a minimal chat UI inspired by ChatGPT to validate the Electron setup and provide a foundation for future conversation features.
 
 ## Getting Started
 1. Install dependencies:

--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,71 @@
   <head>
     <meta charset="UTF-8" />
     <title>Claude Desktop</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: Arial, Helvetica, sans-serif;
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        background-color: #343541;
+        color: #ececf1;
+      }
+      #messages {
+        flex: 1;
+        overflow-y: auto;
+        padding-bottom: 1rem;
+      }
+      .message {
+        padding: 1rem;
+        display: flex;
+        justify-content: center;
+      }
+      .message.user {
+        background-color: #343541;
+      }
+      .message.bot {
+        background-color: #444654;
+      }
+      .message .bubble {
+        max-width: 800px;
+        width: 100%;
+        white-space: pre-wrap;
+      }
+      #message-form {
+        display: flex;
+        padding: 0.75rem;
+        border-top: 1px solid #4d4d4f;
+        background-color: #40414f;
+      }
+      #message-input {
+        flex: 1;
+        padding: 0.75rem;
+        background-color: transparent;
+        border: none;
+        color: #ececf1;
+      }
+      #message-form button {
+        margin-left: 0.5rem;
+        padding: 0.75rem 1rem;
+        background-color: #10a37f;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+      }
+    </style>
   </head>
   <body>
-    <h1>Hello Claude!</h1>
-    <p>Your Electron app is running.</p>
+    <div id="messages"></div>
+    <form id="message-form">
+      <input
+        id="message-input"
+        type="text"
+        placeholder="Send a message..."
+        autocomplete="off"
+      />
+      <button type="submit">Send</button>
+    </form>
+    <script src="renderer.js"></script>
   </body>
 </html>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,29 @@
+const appendMessage = (sender, text) => {
+  const messagesDiv = document.getElementById('messages');
+  const messageDiv = document.createElement('div');
+  messageDiv.classList.add('message', sender);
+
+  const bubble = document.createElement('div');
+  bubble.classList.add('bubble');
+  bubble.textContent = text;
+
+  messageDiv.appendChild(bubble);
+  messagesDiv.appendChild(messageDiv);
+  messagesDiv.scrollTop = messagesDiv.scrollHeight;
+};
+
+document.getElementById('message-form').addEventListener('submit', (e) => {
+  e.preventDefault();
+  const input = document.getElementById('message-input');
+  const text = input.value.trim();
+  if (!text) return;
+
+  appendMessage('user', text);
+  input.value = '';
+  input.focus();
+
+  // For now, simply echo back the user's message as a placeholder.
+  setTimeout(() => {
+    appendMessage('bot', `You said: ${text}`);
+  }, 500);
+});


### PR DESCRIPTION
## Summary
- restyle chat layout and input for a ChatGPT-like dark theme
- modernize renderer logic and focus input after sending messages
- document updated UI in README
- remove unsupported binary screenshot

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8706e31883208cb090f83a1eb05c